### PR TITLE
include_dirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ from setuptools import setup, Extension
 
 zookeepermodule = Extension("zookeeper",
                             sources=["zookeeper.c"],
-                            include_dirs=["/usr/include/c-client-src", "/usr/local/include/c-client-src"],
+                            include_dirs=["/usr/include/c-client-src", "/usr/local/include/c-client-src",
+                                    "/usr/include/zookeeper", "/usr/local/include/zookeeper"],
                             libraries=["zookeeper_mt"],
                             )
 


### PR DESCRIPTION
Using libzookeeper-mt-dev-3.3.5, on Ubuntu 12.04, the header files exist
under /usr/include/zookeeper.

Also, In ZooKeeper 3.4.0 and later, the header files will exist under
INCDIR/zookeeper, instead of INCDIR/c-client-src.
https://issues.apache.org/jira/browse/ZOOKEEPER-1033
